### PR TITLE
Fix text localization resource loading

### DIFF
--- a/Project/core/ModManager.cs
+++ b/Project/core/ModManager.cs
@@ -228,6 +228,17 @@ public partial class ModManager : Node
 				if (SaveManager.FindTextLocaleIndex(locale.LocaleId) != -1) // Already exists
 					continue;
 
+				string resourcePath = $"res://locale/Locale.{locale.LocaleId}.translation";
+
+				if (!ResourceLoader.Exists(resourcePath))
+				{
+					GD.PrintErr($"Can't find optimized translation resource {resourcePath}, text localization {locale.LocaleId} won't be loaded");
+					continue;
+				}
+
+				OptimizedTranslation translation = (OptimizedTranslation)ResourceLoader.Load(resourcePath);
+				TranslationServer.AddTranslation(translation);
+
 				SaveManager.Instance.TextLocalizations.Add(locale);
 			}
 			else


### PR DESCRIPTION
Now the game loads the translation file in a **text** translation mod. 

After the LocalizationResource file is found, the game searches for `res://locale/Locale.(locale id).translation` file. 
If it exists, the game adds it to the TranslationServer and to the SaveManager. 